### PR TITLE
Small bugfix: enable the model to work with non-squared inputs

### DIFF
--- a/graphs/models/decoder.py
+++ b/graphs/models/decoder.py
@@ -43,7 +43,7 @@ class Decoder(nn.Module):
         low_level_feature = self.conv1(low_level_feature)
         low_level_feature = self.bn1(low_level_feature)
         low_level_feature = self.relu(low_level_feature)
-        x_4 = F.interpolate(x, size=low_level_feature.size()[2:3], mode='bilinear' ,align_corners=True)
+        x_4 = F.interpolate(x, size=low_level_feature.size()[2:4], mode='bilinear' ,align_corners=True)
         x_4_cat = torch.cat((x_4, low_level_feature), dim=1)
         x_4_cat = self.conv2(x_4_cat)
         x_4_cat = self.bn2(x_4_cat)
@@ -82,7 +82,7 @@ class DeepLab(nn.Module):
 
         x = self.encoder(x)
         predict = self.decoder(x, low_level_features)
-        output= F.interpolate(predict, size=input.size()[2:3], mode='bilinear', align_corners=True)
+        output= F.interpolate(predict, size=input.size()[2:4], mode='bilinear', align_corners=True)
         return output
 
     def freeze_bn(self):
@@ -102,6 +102,3 @@ if __name__ =="__main__":
     for m in model.modules():
         if isinstance(m, SynchronizedBatchNorm2d):
             print(m)
-
-
-

--- a/graphs/models/encoder.py
+++ b/graphs/models/encoder.py
@@ -60,7 +60,7 @@ class AsppModule(nn.Module):
         input3 = self._atrous_convolution3(input)
         input4 = self._atrous_convolution4(input)
         input5 = self._image_pool(input)
-        input5 = F.interpolate(input=input5, size=input4.size()[2:3], mode='bilinear', align_corners=True)
+        input5 = F.interpolate(input=input5, size=input4.size()[2:4], mode='bilinear', align_corners=True)
 
         return torch.cat((input1, input2, input3, input4, input5), dim=1)
 
@@ -107,5 +107,3 @@ if __name__ =="__main__":
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model = model.to(device)
     summary(model, (3, 512, 512))
-
-


### PR DESCRIPTION
By slicing the size tensor with [2:3] we keep only one dimension (2) since the upper bound (3) is non-inclusive. As a consequence, only one value is used and "F.interpolate" produces always a squared tensor. I tested the network with this fix and it works with non squared inputs.